### PR TITLE
feat: add link expansion class with function and accompanying unit tests

### DIFF
--- a/client_app/app/build.gradle.kts
+++ b/client_app/app/build.gradle.kts
@@ -81,4 +81,6 @@ dependencies {
 
     implementation("androidx.viewpager2:viewpager2:1.0.0")
     implementation ("androidx.cardview:cardview:1.0.0")
+
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
 }

--- a/client_app/app/src/main/java/com/example/sneakylinky/service/LinkExpander.kt
+++ b/client_app/app/src/main/java/com/example/sneakylinky/service/LinkExpander.kt
@@ -1,0 +1,173 @@
+package com.example.sneakylinky.service
+
+import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import java.io.IOException
+
+/**
+ * `LinkChecker` is a utility object used to inspect URLs **without automatically following redirects**.
+ *
+ * The core functionality is to perform a HEAD-only probe on a given URL and manually follow redirects
+ * up to a caller-defined maximum. It returns the final resolved URL or a descriptive failure result.
+ *
+ * We use the HTTP **HEAD** method because it allows checking the URL's existence and redirection
+ * behavior **without downloading the response body**. This makes it:
+ *
+ * - **Faster**: since there's no payload to download.
+ * - **Safer**: especially in security-sensitive contexts (e.g. phishing detection), where we want to
+ *   avoid triggering side effects or loading malicious content from the target server.
+ * - **Lighter on bandwidth**: which is important for mobile and bulk URL scanning use cases.
+ *
+ * It is especially useful in security-sensitive applications (e.g. phishing detection), where
+ * automatic redirect following is discouraged.
+ */
+object LinkChecker {
+
+    /** Default limit for maximum redirects to follow manually */
+    private const val DEFAULT_REDIRECT_LIMIT = 5
+
+    /** Internal HTTP client configured to *not* follow redirects automatically. */
+    internal val client: OkHttpClient = OkHttpClient.Builder()
+        .followRedirects(false)
+        .followSslRedirects(false)
+        .build()
+
+    /**
+     * Represents the result of attempting to resolve a URL.
+     */
+    sealed class UrlResolutionResult {
+
+        data class Success(
+            val originalUrl: String,
+            val finalUrl: String,
+            val redirectCount: Int,
+            val finalStatusCode: Int
+        ) : UrlResolutionResult()
+
+        data class Failure(
+            val originalUrl: String,
+            val error: ErrorCause,
+            val redirectCount: Int = 0
+        ) : UrlResolutionResult()
+
+        enum class ErrorCause(val code: Int, val description: String) {
+            INVALID_URL(1, "The supplied URL is invalid or not absolute"),
+            LOOP_DETECTED(2, "A redirect loop was detected"),
+            EXCEEDED_REDIRECT_LIMIT(3, "The redirect chain exceeded the allowed limit"),
+            UNRECOVERABLE_LOCATION(
+                4,
+                "Redirect response missing or containing invalid Location header"
+            ),
+            NETWORK_EXCEPTION(5, "Network error, timeout or request cancelled"),
+            UNKNOWN(6, "An unknown error occurred")
+        }
+    }
+
+        /**
+         * Attempts to resolve a given URL by issuing only HTTP HEAD requests.
+         * Follows redirects manually up to a specified limit.
+         *
+         * @param url Absolute URL to inspect.
+         * @param maxRedirects Maximum number of redirect hops to follow (default is 5).
+         * @return A [UrlResolutionResult] representing either a success or a failure.
+         */
+        fun resolveUrl(
+            url: String,
+            maxRedirects: Int = DEFAULT_REDIRECT_LIMIT
+        ): UrlResolutionResult {
+
+            println("🔍 Resolving URL: $url")
+            var current = HttpUrl.parse(url)
+                ?: return UrlResolutionResult.Failure(
+                    url,
+                    UrlResolutionResult.ErrorCause.INVALID_URL
+                )
+
+            val visited = mutableSetOf<HttpUrl>()
+            var hops = 0
+
+            while (hops <= maxRedirects) {
+
+                try {
+                    client.newCall(buildHeadRequest(current)).execute().use { res ->
+
+                        when {
+                            res.code() < 300 || res.code() >= 400 -> {
+                                return UrlResolutionResult.Success(
+                                    url,
+                                    current.toString(),
+                                    hops,
+                                    res.code()
+                                )
+                            }
+
+                            res.code() in 300..399 -> {
+                                val next = nextHop(res)
+
+                                if (next == null) {
+                                    return UrlResolutionResult.Failure(
+                                        url,
+                                        UrlResolutionResult.ErrorCause.UNRECOVERABLE_LOCATION,
+                                        hops
+                                    )
+                                }
+
+                                if (!visited.add(next)) {
+                                    return UrlResolutionResult.Failure(
+                                        url,
+                                        UrlResolutionResult.ErrorCause.LOOP_DETECTED,
+                                        hops
+                                    )
+                                }
+
+                                current = next
+                                hops++
+                            }
+
+                            else -> {}
+                        }
+                    }
+                } catch (e: IOException) {
+                    return UrlResolutionResult.Failure(
+                        url,
+                        UrlResolutionResult.ErrorCause.NETWORK_EXCEPTION,
+                        hops
+                    )
+                } catch (e: Exception) {
+                    return UrlResolutionResult.Failure(
+                        url,
+                        UrlResolutionResult.ErrorCause.UNKNOWN,
+                        hops
+                    )
+                }
+            }
+
+            return UrlResolutionResult.Failure(
+                url,
+                UrlResolutionResult.ErrorCause.EXCEEDED_REDIRECT_LIMIT,
+                hops
+            )
+        }
+
+
+    /** Builds a HEAD request for the specified URL. */
+    private fun buildHeadRequest(url: HttpUrl): Request =
+        Request.Builder()
+            .url(url)
+            .head()
+            .build()
+
+    /** Extracts the next redirect hop from the Location header. */
+    private fun nextHop(res: Response): HttpUrl? {
+        val location = res.header("Location") ?: return null
+
+
+        HttpUrl.parse(location)?.let { return it }
+
+        return res.request().url().resolve(location)
+    }
+
+}
+

--- a/client_app/app/src/main/java/com/example/sneakylinky/service/utils2.kt
+++ b/client_app/app/src/main/java/com/example/sneakylinky/service/utils2.kt
@@ -1,2 +1,0 @@
-package com.example.sneakylinky.service
-

--- a/client_app/app/src/test/java/com/example/sneakylinky/LinkExpanderTest.kt
+++ b/client_app/app/src/test/java/com/example/sneakylinky/LinkExpanderTest.kt
@@ -1,0 +1,228 @@
+@file:Suppress("SameParameterValue")
+
+package com.example.sneakylinky
+
+import com.example.sneakylinky.service.LinkChecker
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.Assert.*      // assertEquals / assertTrue / assertThat וכו'
+
+class LinkCheckerTest {
+
+    private lateinit var server: MockWebServer
+
+    /* ───────────── Lifecycle ───────────── */
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    /* ───────────── Helpers ───────────── */
+
+    /** Enqueue a simple (empty-body) HEAD response with optional Location header. */
+    private fun enqueueHead(status: Int, location: String? = null) {
+        val response = MockResponse().setResponseCode(status).setBody("")
+        location?.let { response.setHeader("Location", it) }
+        server.enqueue(response)
+    }
+
+    /** Convenience to build an absolute URL served by the mock server. */
+    private fun mockUrl(path: String) = server.url(path).toString()
+
+    /* ───────────── Tests ───────────── */
+
+    @Test
+    fun noRedirect_returnsSuccessWith200() {
+        // Arrange
+        enqueueHead(200)
+        val url = mockUrl("/ok")
+
+        // Act
+        val result = LinkChecker.resolveUrl(url)
+
+        // Assert
+        assertTrue(result is LinkChecker.UrlResolutionResult.Success)
+        result as LinkChecker.UrlResolutionResult.Success
+        assertEquals(url, result.finalUrl)
+        assertEquals(0, result.redirectCount)
+        assertEquals(200, result.finalStatusCode)
+    }
+
+    @Test
+    fun singleRedirect_resolvesWithOneHop() {
+        // Arrange
+        val targetUrl = mockUrl("/final")
+        enqueueHead(302, targetUrl)  // hop #0
+        enqueueHead(200)             // hop #1
+
+        // Act
+        val result = LinkChecker.resolveUrl(mockUrl("/start"))
+
+        // Assert
+        assertTrue(result is LinkChecker.UrlResolutionResult.Success)
+        result as LinkChecker.UrlResolutionResult.Success
+        assertEquals(targetUrl, result.finalUrl)
+        assertEquals(1, result.redirectCount)
+        assertEquals(200, result.finalStatusCode)
+    }
+
+    @Test
+    fun multipleRedirectsWithinLimit_returnsSuccess() {
+        // Arrange
+        val hop1 = mockUrl("/1")
+        val hop2 = mockUrl("/2")
+        val hop3 = mockUrl("/3")
+        enqueueHead(301, hop1)
+        enqueueHead(302, hop2)
+        enqueueHead(307, hop3)
+        enqueueHead(200)
+
+        // Act
+        val result = LinkChecker.resolveUrl(mockUrl("/start"))
+
+        // Assert
+        assertTrue(result is LinkChecker.UrlResolutionResult.Success)
+        result as LinkChecker.UrlResolutionResult.Success
+        assertEquals(hop3, result.finalUrl)
+        assertEquals(3, result.redirectCount)
+    }
+
+    @Test
+    fun redirectLoop_returnsLoopDetected() {
+        // Arrange
+        val loopUrl = mockUrl("/loop")
+        enqueueHead(301, loopUrl)
+        enqueueHead(301, loopUrl)     // same Location repeated
+
+        // Act
+        val result = LinkChecker.resolveUrl(loopUrl)
+
+        // Assert
+        assertTrue(result is LinkChecker.UrlResolutionResult.Failure)
+        result as LinkChecker.UrlResolutionResult.Failure
+        assertEquals(LinkChecker.UrlResolutionResult.ErrorCause.LOOP_DETECTED, result.error)
+    }
+
+    @Test
+    fun exceedsRedirectLimit_returnsExceeded() {
+        // Arrange – 6 redirects > default 5
+        repeat(6) { enqueueHead(302, mockUrl("/$it")) }
+
+        // Act
+        val result = LinkChecker.resolveUrl(mockUrl("/start"))
+
+        // Assert
+        assertTrue(result is LinkChecker.UrlResolutionResult.Failure)
+        result as LinkChecker.UrlResolutionResult.Failure
+        assertEquals(LinkChecker.UrlResolutionResult.ErrorCause.EXCEEDED_REDIRECT_LIMIT, result.error)
+        assertTrue(result.redirectCount > 5)
+    }
+
+    @Test
+    fun missingLocationHeader_returnsUnrecoverableLocation() {
+        // Arrange
+        enqueueHead(302)              // 302 without Location
+
+        // Act
+        val result = LinkChecker.resolveUrl(mockUrl("/broken"))
+
+        // Assert
+        assertTrue(result is LinkChecker.UrlResolutionResult.Failure)
+        result as LinkChecker.UrlResolutionResult.Failure
+        assertEquals(LinkChecker.UrlResolutionResult.ErrorCause.UNRECOVERABLE_LOCATION, result.error)
+    }
+
+    @Test
+    fun invalidUrl_returnsInvalidUrl() {
+        // Act
+        val result = LinkChecker.resolveUrl("ht!tp:// bad url")
+
+        // Assert
+        assertTrue(result is LinkChecker.UrlResolutionResult.Failure)
+        result as LinkChecker.UrlResolutionResult.Failure
+        assertEquals(LinkChecker.UrlResolutionResult.ErrorCause.INVALID_URL, result.error)
+    }
+
+    @Test
+    fun finalStatus403_stillSuccess() {
+        // Arrange
+        enqueueHead(403)
+
+        // Act
+        val result = LinkChecker.resolveUrl(mockUrl("/forbidden"))
+
+        // Assert
+        assertTrue(result is LinkChecker.UrlResolutionResult.Success)
+        result as LinkChecker.UrlResolutionResult.Success
+        assertEquals(403, result.finalStatusCode)
+    }
+
+    @Test
+    fun headNotAllowed405_stillSuccess() {
+        // Arrange
+        enqueueHead(405)
+
+        // Act
+        val result = LinkChecker.resolveUrl(mockUrl("/head-not-allowed"))
+
+        // Assert
+        assertTrue(result is LinkChecker.UrlResolutionResult.Success)
+        result as LinkChecker.UrlResolutionResult.Success
+        assertEquals(405, result.finalStatusCode)
+    }
+
+    @Test
+    fun networkException_returnsNetworkError() {
+        // Arrange – shut server before making request
+        server.shutdown()
+        val unreachable = mockUrl("/down")
+
+        // Act
+        val result = LinkChecker.resolveUrl(unreachable)
+
+        // Assert
+        assertTrue(result is LinkChecker.UrlResolutionResult.Failure)
+        result as LinkChecker.UrlResolutionResult.Failure
+        assertEquals(LinkChecker.UrlResolutionResult.ErrorCause.NETWORK_EXCEPTION, result.error)
+    }
+
+
+    @Test
+    fun garbageLocation_returnsUnrecoverableLocation() {
+        enqueueHead(302, null)             // no Location header
+        val result = LinkChecker.resolveUrl(mockUrl("/start"))
+        assertTrue(result is LinkChecker.UrlResolutionResult.Failure)
+        result as LinkChecker.UrlResolutionResult.Failure
+        assertEquals(
+            LinkChecker.UrlResolutionResult.ErrorCause.UNRECOVERABLE_LOCATION,
+            result.error
+        )
+    }
+
+    @Test
+    fun customRedirectLimitIsHonoured() {
+        // Arrange – 2 redirects but limit = 1
+        val hop1 = mockUrl("/hop1")
+        enqueueHead(302, hop1)
+        enqueueHead(302, mockUrl("/hop2"))
+
+        // Act
+        val result = LinkChecker.resolveUrl(mockUrl("/start"), maxRedirects = 1)
+
+        // Assert
+        assertTrue(result is LinkChecker.UrlResolutionResult.Failure)
+        result as LinkChecker.UrlResolutionResult.Failure
+        assertEquals(LinkChecker.UrlResolutionResult.ErrorCause.EXCEEDED_REDIRECT_LIMIT, result.error)
+        assertEquals(2, result.redirectCount)
+    }
+}


### PR DESCRIPTION
- Implemented core function to resolve and expand shortened or redirected URLs.
- Manually follows HTTP redirects using HEAD requests to determine final destination.
- Added unit tests to validate success, redirect chains, and failure edge cases.


/**
 * Example usage for LinkChecker.resolveUrl()
 */
fun main() {
    val original = "https://bit.ly/3abcXYZ"   // any short / redirecting URL
    val result = LinkChecker.resolveUrl(original)

    when (result) {
        is LinkChecker.UrlResolutionResult.Success -> {
            println(
                """
                ✅ Resolved!
                • Original : ${result.originalUrl}
                • Final    : ${result.finalUrl}
                • Hops     : ${result.redirectCount}
                • Status   : ${result.finalStatusCode}
                """.trimIndent()
            )
        }

        is LinkChecker.UrlResolutionResult.Failure -> {
            println(
                """
                ❌ Failed to resolve ${result.originalUrl}
                • After   : ${result.redirectCount} hops
                • Reason  : ${result.error.description}
                """.trimIndent()
            )
        }
    }
}